### PR TITLE
Add test for unicode completions in javascript

### DIFF
--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -305,3 +305,75 @@ def GetCompletions_ReturnsDocsInCompletions_test( app ):
       } )
     },
   } )
+
+
+@SharedYcmd
+def GetCompletions_Unicode_AfterLine_test( app ):
+  RunTest( app, {
+    'description': 'completions work with unicode chars in the file',
+    'request': {
+      'filetype'  : 'javascript',
+      'filepath'  : PathToTestFile( 'unicode.js' ),
+      'line_num'  : 1,
+      'column_num': 16,
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'completions': contains_inanyorder(
+          CompletionEntryMatcher( 'charAt', 'fn(i: number) -> string' ),
+          CompletionEntryMatcher( 'charCodeAt', 'fn(i: number) -> number' ),
+        ),
+        'completion_start_column': 13,
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_Unicode_InLine_test( app ):
+  RunTest( app, {
+    'description': 'completions work with unicode chars in the file',
+    'request': {
+      'filetype'  : 'javascript',
+      'filepath'  : PathToTestFile( 'unicode.js' ),
+      'line_num'  : 2,
+      'column_num': 16,
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'completions': contains_inanyorder(
+          CompletionEntryMatcher( 'charAt', 'fn(i: number) -> string' ),
+          CompletionEntryMatcher( 'charCodeAt', 'fn(i: number) -> number' ),
+        ),
+        'completion_start_column': 13,
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_Unicode_InFile_test( app ):
+  RunTest( app, {
+    'description': 'completions work with unicode chars in the file',
+    'request': {
+      'filetype'  : 'javascript',
+      'filepath'  : PathToTestFile( 'unicode.js' ),
+      'line_num'  : 3,
+      'column_num': 16,
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'completions': contains_inanyorder(
+          CompletionEntryMatcher( 'charAt', 'fn(i: number) -> string' ),
+          CompletionEntryMatcher( 'charCodeAt', 'fn(i: number) -> number' ),
+        ),
+        'completion_start_column': 13,
+        'errors': empty(),
+      } )
+    },
+  } )

--- a/ycmd/tests/javascript/testdata/unicode.js
+++ b/ycmd/tests/javascript/testdata/unicode.js
@@ -1,0 +1,3 @@
+var x = 't'.chA
+var y = '†'.chA
+var x = 't'.chA


### PR DESCRIPTION
Confirm this test fails with current master:

```
#230 ycmd.tests.utils_test.SetEnviron_UnicodeOnWindows_test ... ok

======================================================================
FAIL: ycmd.tests.javascript.get_completions_test.GetCompletions_Unicode_InLine_test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/lindsayjackson/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/runtime/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/lindsayjackson/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/ycmd/tests/javascript/__init__.py", line 103, in Wrapper
    return test( shared_app, *args, **kwargs )
  File "/Users/lindsayjackson/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/ycmd/tests/javascript/get_completions_test.py", line 352, in GetCompletions_Unicode_InLine_test
    'errors': empty(),
  File "/Users/lindsayjackson/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/ycmd/tests/javascript/get_completions_test.py", line 85, in RunTest
    assert_that( response.json, test[ 'expect' ][ 'data' ] )
AssertionError:
Expected: a dictionary containing {'completion_start_column': <13>, 'completions': a sequence over [a dictionary containing {'extra_menu_info': 'fn(i: number) -> string', 'insertion_text': 'charAt'}, a dictionary containing {'extra_menu_info': 'fn(i: number) -> number', 'insertion_text': 'charCodeAt'}] in any order, 'errors': an empty collection}
     but: value for 'completion_start_column' was <15>

-------------------- >> begin captured stdout << ---------------------
completer response: {u'completion_start_column': 15, u'completions': [], u'errors': []}

--------------------- >> end captured stdout << ----------------------
-------------------- >> begin captured logging << --------------------
ycmd.handlers: INFO: Received event notification
ycmd.handlers: DEBUG: Event name: FileReadyToParse
ycmd.completers.all.identifier_completer: INFO: Adding buffer identifiers for file: /Users/lindsayjackson/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/ycmd/tests/javascript/testdata/unicode.js
requests.packages.urllib3.connectionpool: INFO: Starting new HTTP connection (1): 127.0.0.1
requests.packages.urllib3.connectionpool: DEBUG: "POST / HTTP/1.1" 200 None
ycmd.handlers: INFO: Received completion request
ycmd.handlers: DEBUG: Using filetype completion: False
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 278 tests in 2.187s

FAILED (SKIP=11, failures=1)
Traceback (most recent call last):
  File "./run_tests.py", line 218, in <module>
    Main()
  File "./run_tests.py", line 215, in Main
    NoseTests( parsed_args, nosetests_args )
  File "./run_tests.py", line 206, in NoseTests
    subprocess.check_call( [ 'nosetests' ] + nosetests_args )
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '[u'nosetests', u'-v', u'--with-id', u'--exclude-dir=ycmd/tests/typescript', u'--exclude-dir=ycmd/tests/python', u'--exclude-dir=ycmd/tests/clang', u'--exclude-dir=ycmd/tests/go', u'--exclude-dir=ycmd/tests/cs', u'--exclude-dir=ycmd/tests/rust', u'/Users/lindsayjackson/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/ycmd']' returned non-zero exit status 1
```

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/micbou/ycmd/2)

<!-- Reviewable:end -->
